### PR TITLE
Use prompt=none for silent login and fallback on auth error

### DIFF
--- a/lib/constants/cookies.ts
+++ b/lib/constants/cookies.ts
@@ -1,3 +1,5 @@
 export const envIdCookieName = "currentEnvId";
 
 export const previewApiKeyCookieName = "currentPreviewApiKey";
+
+export const urlAfterAuthCookieName = "urlAfterAuth";

--- a/pages/callback.tsx
+++ b/pages/callback.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 import { BuildError } from "../components/shared/ui/BuildError";
 import { webAuth } from "../lib/constants/auth";
 import { mainColorTextClass } from "../lib/constants/colors";
-import { envIdCookieName, previewApiKeyCookieName } from "../lib/constants/cookies";
+import { envIdCookieName, previewApiKeyCookieName, urlAfterAuthCookieName } from "../lib/constants/cookies";
 import { internalApiDomain, siteCodename } from "../lib/utils/env";
 
 const CallbackPage: React.FC = () => {
@@ -83,6 +83,9 @@ const CallbackPage: React.FC = () => {
     };
 
     webAuth.parseHash({ hash: window.location.hash }, async (err, authResult) => {
+      if (err?.error && requiresLoginAuthErrors.includes(err.error)) {
+        return window.location.replace(`/getPreviewApiKey?promptLogin&path=${getCookie(urlAfterAuthCookieName)}`);
+      }
       if (err) {
         return setError(err.errorDescription ?? err.error);
       }
@@ -133,3 +136,5 @@ const Loader = () => (
     <span className="sr-only">Loading...</span>
   </div >
 );
+
+const requiresLoginAuthErrors: ReadonlyArray<string> = ["login_required", "consent_required", "interaction_required"];

--- a/pages/getPreviewApiKey.ts
+++ b/pages/getPreviewApiKey.ts
@@ -1,12 +1,14 @@
+import { setCookie } from "cookies-next";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { FC, useEffect } from "react";
 
 import { webAuth } from "../lib/constants/auth";
+import { urlAfterAuthCookieName } from "../lib/constants/cookies";
 
 const GetPreviewApiKey: FC = () => {
   const router = useRouter();
-  const { path } = router.query;
+  const { path, promptLogin } = router.query;
 
   useEffect(() => {
     if (!router.isReady) { // We need to wait until the component is hydrated, because otherwise router.query is empty (https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization)
@@ -15,9 +17,10 @@ const GetPreviewApiKey: FC = () => {
     if (!path) {
       console.warn("Missing query parameter 'path' in /getPreviewApiKey. Will redirect to / after auth.");
     }
-    webAuth.authorize({ redirectUri: `${window.origin}/callback`, appState: path });
+    setCookie(urlAfterAuthCookieName, path);
+    webAuth.authorize({ redirectUri: `${window.origin}/callback`, prompt: typeof promptLogin === "string" ? undefined : "none" });
 
-  }, [path, router.isReady])
+  }, [path, router.isReady, promptLogin])
 
   return null;
 }


### PR DESCRIPTION
### Motivation

This simplifies the authentication flow. With the added `prompt` parameter, it is not necessary to enter your credentials again when you already logged in before.

### How to test

Check that the auth flow works as it should in all kinds of different scenarios.
