### PR TITLE
Use cookie to redirect after auth (instead of appState)

### DIFF
--- a/lib/constants/cookies.ts
+++ b/lib/constants/cookies.ts
@@ -3,3 +3,5 @@ export const envIdCookieName = "currentEnvId";
 export const previewApiKeyCookieName = "currentPreviewApiKey";
 
 export const urlAfterAuthCookieName = "urlAfterAuth";
+
+export const defaultCookieOptions = { path: '/', sameSite: 'none', secure: true } as const;

--- a/lib/utils/pageUtils.ts
+++ b/lib/utils/pageUtils.ts
@@ -1,7 +1,7 @@
 import { getCookie } from "cookies-next";
 import { GetStaticPropsContext, PreviewData } from "next";
 
-import { envIdCookieName, previewApiKeyCookieName } from "../constants/cookies";
+import { defaultCookieOptions, envIdCookieName, previewApiKeyCookieName } from "../constants/cookies";
 import { defaultEnvId } from "./env";
 
 export const getEnvIdFromRouteParams = (context: GetStaticPropsContext): string => {
@@ -19,4 +19,4 @@ export const getPreviewApiKeyFromPreviewData = (previewData: PreviewData | undef
     ? previewData.currentPreviewApiKey as string
     : undefined;
 
-export const getEnvIdFromCookie = () => getCookie(envIdCookieName, { path: '/', sameSite: 'none' });
+export const getEnvIdFromCookie = () => getCookie(envIdCookieName, defaultCookieOptions);

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import { envIdCookieName, previewApiKeyCookieName } from './lib/constants/cookies';
+import { defaultCookieOptions, envIdCookieName, previewApiKeyCookieName } from './lib/constants/cookies';
 import { createQueryString } from './lib/routing';
 import { defaultEnvId } from './lib/utils/env';
 
@@ -43,7 +43,7 @@ const handleExplicitProjectRoute = (currentEnvId: string) => (prevResponse: Next
 
   if (routeEnvId === defaultEnvId) {
     const res = NextResponse.redirect(new URL(createUrlWithQueryString(remainingUrl, request.nextUrl.searchParams.entries()), request.nextUrl.origin));
-    res.cookies.set(envIdCookieName, defaultEnvId, cookieOptions);
+    res.cookies.set(envIdCookieName, defaultEnvId, defaultCookieOptions);
     res.cookies.set(previewApiKeyCookieName, "", cookieDeleteOptions);
 
     return res
@@ -54,7 +54,7 @@ const handleExplicitProjectRoute = (currentEnvId: string) => (prevResponse: Next
     const redirectPath = `/api/exit-preview?callback=${originalPath}`; // We need to exit preview, because the old preview API key is in preview data
     const res = NextResponse.redirect(new URL(redirectPath, request.nextUrl.origin));
 
-    res.cookies.set(envIdCookieName, routeEnvId, cookieOptions);
+    res.cookies.set(envIdCookieName, routeEnvId, defaultCookieOptions);
     res.cookies.set(previewApiKeyCookieName, "", cookieDeleteOptions);
 
     return res;
@@ -70,7 +70,7 @@ const handleEmptyApiKeyCookie = (currentEnvId: string) => (prevResponse: NextRes
 
   if (currentEnvId === defaultEnvId) {
     const res = NextResponse.redirect(request.url); // Workaround for this issue https://github.com/vercel/next.js/issues/49442, we cannot set cookies on NextResponse.next()
-    res.cookies.set(previewApiKeyCookieName, KONTENT_PREVIEW_API_KEY, cookieOptions);
+    res.cookies.set(previewApiKeyCookieName, KONTENT_PREVIEW_API_KEY, defaultCookieOptions);
     return res;
   }
 
@@ -95,7 +95,7 @@ const handleArticlesCategoryWithNoPaginationRoute = (currentEnvId: string) => (p
 
 const handleEmptyCookies = (prevResponse: NextResponse, request: NextRequest) => {
   if (!request.cookies.get(envIdCookieName)?.value && !prevResponse.cookies.get(envIdCookieName)) {
-    prevResponse.cookies.set(envIdCookieName, defaultEnvId, cookieOptions);
+    prevResponse.cookies.set(envIdCookieName, defaultEnvId, defaultCookieOptions);
   }
 
   return prevResponse;
@@ -114,5 +114,4 @@ export const config = {
   ],
 };
 
-const cookieOptions = { path: '/', sameSite: 'none', secure: true } as const;
-const cookieDeleteOptions = { ...cookieOptions, maxAge: -1 } as const; // It seems that res.cookies.delete doesn't propagate provided options (we need sameSite: none) so we use this as a workaround
+const cookieDeleteOptions = { ...defaultCookieOptions, maxAge: -1 } as const; // It seems that res.cookies.delete doesn't propagate provided options (we need sameSite: none) so we use this as a workaround

--- a/pages/callback.tsx
+++ b/pages/callback.tsx
@@ -6,8 +6,9 @@ import { useEffect, useState } from "react";
 import { BuildError } from "../components/shared/ui/BuildError";
 import { webAuth } from "../lib/constants/auth";
 import { mainColorTextClass } from "../lib/constants/colors";
-import { envIdCookieName, previewApiKeyCookieName, urlAfterAuthCookieName } from "../lib/constants/cookies";
+import { defaultCookieOptions, previewApiKeyCookieName, urlAfterAuthCookieName } from "../lib/constants/cookies";
 import { internalApiDomain, siteCodename } from "../lib/utils/env";
+import { getEnvIdFromCookie } from "../lib/utils/pageUtils";
 
 const CallbackPage: React.FC = () => {
   const router = useRouter();
@@ -17,7 +18,7 @@ const CallbackPage: React.FC = () => {
     if (!router.isReady) {
       return;
     }
-    const envId = getCookie(envIdCookieName, { path: '/', sameSite: 'none' });
+    const envId = getEnvIdFromCookie();
 
     if (!internalApiDomain) {
       console.log("Enviroment variable KONTENT_DOMAIN is empty");
@@ -101,7 +102,7 @@ const CallbackPage: React.FC = () => {
       const api_key = await getPreviewApiKey(authResult.accessToken, projectContainerId);
 
       if (typeof api_key === "string") {
-        setCookie(previewApiKeyCookieName, api_key, { path: '/', sameSite: 'none', secure: true })
+        setCookie(previewApiKeyCookieName, api_key, defaultCookieOptions);
       }
       else {
         return setError(api_key.error);

--- a/pages/callback.tsx
+++ b/pages/callback.tsx
@@ -84,7 +84,7 @@ const CallbackPage: React.FC = () => {
 
     webAuth.parseHash({ hash: window.location.hash }, async (err, authResult) => {
       if (err?.error && requiresLoginAuthErrors.includes(err.error)) {
-        return window.location.replace(`/getPreviewApiKey?promptLogin&path=${getCookie(urlAfterAuthCookieName)}`);
+        return window.location.replace(`/getPreviewApiKey?promptLogin&path=${encodeURIComponent(getCookie(urlAfterAuthCookieName) ?? "")}`);
       }
       if (err) {
         return setError(err.errorDescription ?? err.error);
@@ -107,7 +107,7 @@ const CallbackPage: React.FC = () => {
         return setError(api_key.error);
       }
 
-      window.location.replace(authResult.appState ?? '/'); // router.replace changes the "slug" query parameter so we can't use it here, because this parameter is used when calling the /api/preview endpoint
+      window.location.replace(getCookie(urlAfterAuthCookieName) ?? '/'); // router.replace changes the "slug" query parameter so we can't use it here, because this parameter is used when calling the /api/preview endpoint
     });
   }, [router.isReady]);
 

--- a/pages/getPreviewApiKey.ts
+++ b/pages/getPreviewApiKey.ts
@@ -4,7 +4,7 @@ import { useRouter } from "next/router";
 import { FC, useEffect } from "react";
 
 import { webAuth } from "../lib/constants/auth";
-import { urlAfterAuthCookieName } from "../lib/constants/cookies";
+import { defaultCookieOptions, urlAfterAuthCookieName } from "../lib/constants/cookies";
 
 const GetPreviewApiKey: FC = () => {
   const router = useRouter();
@@ -17,7 +17,7 @@ const GetPreviewApiKey: FC = () => {
     if (!path) {
       console.warn("Missing query parameter 'path' in /getPreviewApiKey. Will redirect to / after auth.");
     }
-    setCookie(urlAfterAuthCookieName, path, { path: "/", secure: true, sameSite: "none" });
+    setCookie(urlAfterAuthCookieName, path, defaultCookieOptions);
     webAuth.authorize({ redirectUri: `${window.origin}/callback`, prompt: typeof promptLogin === "string" ? undefined : "none" });
 
   }, [path, router.isReady, promptLogin])

--- a/pages/getPreviewApiKey.ts
+++ b/pages/getPreviewApiKey.ts
@@ -17,7 +17,7 @@ const GetPreviewApiKey: FC = () => {
     if (!path) {
       console.warn("Missing query parameter 'path' in /getPreviewApiKey. Will redirect to / after auth.");
     }
-    setCookie(urlAfterAuthCookieName, path);
+    setCookie(urlAfterAuthCookieName, path, { path: "/", secure: true, sameSite: "none" });
     webAuth.authorize({ redirectUri: `${window.origin}/callback`, prompt: typeof promptLogin === "string" ? undefined : "none" });
 
   }, [path, router.isReady, promptLogin])


### PR DESCRIPTION
- The appState was replaced by the cookie
- also uri encode the path in route when redirecting

### Motivation

Fixes a bug introduced with silent login PR that breaks redirecting after auth. The silent login PR changed the mechanism of passing the redirect url from the `/getPreviewApiKey` to `/callback` from the Auth0 appState to a cookie. This is because the appState is not accessible when the auth call fails. But the PR didn't use the cookie to redirect on an auth success, therefore always redirecting to `/`. This PR fixes that.
