### PR TITLE
Stop using turbopack for dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "generateModels": "tsc --project scripts/tsconfig.json && node scripts/build/generateModels.mjs",
-    "dev": "next dev --turbopack",
-    "dev:https": "next dev --turbopack --experimental-https",
+    "dev": "next dev",
+    "dev:https": "next dev --experimental-https",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "build": "next build",


### PR DESCRIPTION
### Motivation

Turbopack seems to have issues with some loaders when ran on windows, resulting in errors when attempting to run `next dev` with `--turbopack` parameter, particularly with image loader. This error was not reproducible on Mac OS. 

Removing turbopack parameter from dev scripts for now as it isn't crucial for the sample app.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Fill env variables for any collection, run `npm run dev` and check that it renders without errors.